### PR TITLE
Update ssh-keygen command

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Then add **hubot-chatops-rpc** to your `external-scripts.json`:
 Create a public/private key pair for authentication:
 
 ```
-ssh-keygen -t rsa -b 4096 -f crpc
+ssh-keygen -m PEM -t rsa -b 4096 -f crpc
 ```
 
 This will create two files, `crpc` and `crpc.pub`. Use the contents of the


### PR DESCRIPTION
When walking through the installation, the current `ssh-keygen`command was generating `OPENSSH` keys instead of `RSA` in my local environment. We noticed `OPENSSH` keys aren't supported by `hubot-chatops-rpc` and since newer versions of `ssh-keygen` don't generate keys in `PEM` format by default we ran into some signature issues when booting up the server. However, adding the `-m` flag allows us to explicitly pass the format type to avoid this issue.